### PR TITLE
Remove api symlink deletion step from CI workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -46,9 +46,6 @@ jobs:
           # The arduino/actions/libraries/compile-examples action will install the platform from this path
           path: ${{ env.ARDUINOCORE_MBED_STAGING_PATH }}
 
-      - name: Remove ArduinoCore-API symlink from Arduino mbed-Enabled Boards platform
-        run: rm "${{ env.ARDUINOCORE_MBED_STAGING_PATH }}/cores/arduino/api"
-
       - name: Checkout ArduinoCore-API
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The symlink for ArduinoCore-API in the Mbed OS Boards core library has been removed (https://github.com/arduino/ArduinoCore-mbed/commit/ca397e88926c16ccfd7531f842a2d8f0971dcffc). This resulted in the step of the "Compile Examples" CI workflow that removes the now non-existent symlink to fail.