### PR TITLE
Use default branch of ArduinoCore-API in CI workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -53,8 +53,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: arduino/ArduinoCore-API
-          # As specified at https://github.com/arduino/ArduinoCore-mbed/blob/master/README.md#installation
-          ref: namespace_arduino
           path: ${{ env.ARDUINOCORE_API_STAGING_PATH }}
 
       - name: Install ArduinoCore-API


### PR DESCRIPTION
Previously, the `namespace_arduino` branch of ArduinoCore-API was used in the core library of the development version of
the Mbed OS Boards platform used in the "Compile Examples" CI workflow. The default branch of ArduinoCore-API is now the
latest and greatest version, so the `namespace_arduino` branch should no longer be used for the Mbed OS Boards platform's core library (https://github.com/arduino/ArduinoCore-mbed/commit/3c175d7e4df9bbd19d65b5285f163785f28d0fbc).