### PR TITLE
Reduce Arduino Lint compliance level to "specification"

### DIFF
--- a/.github/workflows/check-arduino.yml
+++ b/.github/workflows/check-arduino.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Arduino Lint
         uses: arduino/arduino-lint-action@v1
         with:
-          compliance: strict
+          compliance: specification
           library-manager: update
           # Always use this setting for official repositories. Remove for 3rd party projects.
           official: true


### PR DESCRIPTION
Linting the library in "strict" [compliance mode](https://arduino.github.io/arduino-lint/latest/#compliance-setting) fails due to the `name` value exceeding the recommended maximum of 16 characters.

It is not possible to change the name, so this is not something that can be fixed. The expected error might mask real problems that cause other rule violations in the future. So the best thing is to reduce the compliance level to "specification" in which the library name length rule violation only results in a warning.