### PR TITLE
Switch to contributor-friendly approach to size deltas CI report

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -53,24 +53,3 @@ jobs:
           if-no-files-found: error
           path: ${{ env.SKETCHES_REPORTS_PATH }}
           name: ${{ env.SKETCHES_REPORTS_ARTIFACT_NAME }}
-
-  report:
-    needs: compile-examples
-    # Only run the job when the workflow is triggered by a pull request from this repository (because arduino/report-size-deltas requires write permissions)
-    if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download sketches reports artifact
-        id: download-artifact
-        continue-on-error: true # If compilation failed for all boards then there are no artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: ${{ env.SKETCHES_REPORTS_ARTIFACT_NAME }}
-          path: ${{ env.SKETCHES_REPORTS_PATH }}
-
-      - name: Comment size deltas report to PR
-        uses: arduino/report-size-deltas@v1
-        # If actions/download-artifact failed, there are no artifacts to report from.
-        if: steps.download-artifact.outcome == 'success'
-        with:
-          sketches-reports-source: ${{ env.SKETCHES_REPORTS_PATH }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -1,0 +1,24 @@
+name: Report Size Deltas
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+    paths:
+      - ".github/workflows/report-size-deltas.ya?ml"
+  schedule:
+    # Run at the minimum interval allowed by GitHub Actions.
+    # Note: GitHub Actions periodically has outages which result in workflow failures.
+    # In this event, the workflows will start passing again once the service recovers.
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment size deltas reports to PRs
+        uses: arduino/report-size-deltas@v1
+        with:
+          # The name of the workflow artifact created by the sketch compilation workflow
+          sketches-reports-source: sketches-reports


### PR DESCRIPTION
The CI system makes a report of the change to memory usage of the example sketches that results from the changes made in a pull request. It does this via a comment on the PR thread. In order to do that, it needs write permissions in the repository. As a security precaution, workflow runs triggered by a pull request from a fork are [not given the necessary write permissions](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token).

The workflow was added in the early development phase when the repository was still private. In that situation, the approach of triggering the deltas report from [the `pull_request` event](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request) was the best (due to the limited allowance of GitHub Actions minutes for private repos) but now the repository is public (thus having unlimited free minutes) and it's important to get reports on pull requests that come from forks. So the approach of using a dedicated workflow triggered by [the `schedule` event](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule) 
(which does have write permissions) is better.