### PR TITLE
Update PCF8563T.cpp

### DIFF
--- a/src/utility/RTC/PCF8563T.cpp
+++ b/src/utility/RTC/PCF8563T.cpp
@@ -172,7 +172,7 @@ uint8_t PCF8563TClass::getMonths() {
  *  @return byte with Day(s) value
  */   
 uint8_t PCF8563TClass::getDays() {
-  uint8_t days = readByte(PCF8563T_DAYS_REG);
+  uint8_t days = readByte(PCF8563T_DAYS_REG) & 0x3F;
   return (days & 0x0F) + ((days >> 4)*10);
 }
 


### PR DESCRIPTION
fix bug in getDays() method.

Sometimes the getDays() function returns a value higher than 31. The value is typically 40 days too high and this happens whenever the getSeconds() returns a value higher than 40.

Eg. at 16:40:30 on the 1st of june getDays() returns 1, then 15 seconds later at 16:40:45 getDays() returns 41, and then 20 seconds later at 16:41:05 it returns 1 again.

Unlike the other get-functions in the PCF8563TClass the getDays() function does not filter out the 2 unused MSBs of the day register as it should according to the datasheet. This pr fixes that