### PR TITLE
Fix voltage reference in examples

### DIFF
--- a/examples/Analog_input/Analog_input_0_10V/Analog_input_0_10V.ino
+++ b/examples/Analog_input/Analog_input_0_10V/Analog_input_0_10V.ino
@@ -20,7 +20,7 @@
 using namespace machinecontrol;
 
 float res_divider = 0.28057;
-float reference = 3.3;
+float reference = 3.0;
 
 void setup() {
   analogReadResolution(16);

--- a/examples/Analog_input/Analog_input_4_20mA/Analog_input_4_20mA.ino
+++ b/examples/Analog_input/Analog_input_4_20mA/Analog_input_4_20mA.ino
@@ -21,7 +21,7 @@ using namespace machinecontrol;
 
 #define SENSE_RES 120
 
-float reference = 3.3;
+float reference = 3.0;
 
 void setup() {
   analogReadResolution(16);

--- a/examples/Analog_input/Analog_input_NTC/Analog_input_NTC.ino
+++ b/examples/Analog_input/Analog_input_NTC/Analog_input_NTC.ino
@@ -26,7 +26,7 @@ using namespace machinecontrol;
 
 #define REFERENCE_RES 100000
 
-float reference = 3.3;
+float reference = 3.0;
 float lowest_voltage = 2.7;
 
 void setup() {


### PR DESCRIPTION
The MachineControl boards features a REF3330 3.0 V Reference Voltage.

As mentioned in this https://github.com/arduino-libraries/Arduino_MachineControl/pull/70#issuecomment-1092639038

I have compared the 0-10V input results with an oscilloscope and the values with the 3.3 V reference were wrong but correct with 3.0 V.