### PR TITLE
Fix hour alarm register

### DIFF
--- a/src/utility/RTC/PCF8563T.cpp
+++ b/src/utility/RTC/PCF8563T.cpp
@@ -347,7 +347,7 @@ void PCF8563TClass::setHourAlarm(uint8_t hours) {
   uint8_t dec = hours / 10;
   uint8_t unit = hours - (dec * 10);
   uint8_t hour_alarm = PCF8563T_HOUR_ALARM_AE_H_MASK & ((dec << 4) + unit);
-  writeByte(PCF8563T_HOURS_REG, hour_alarm); //check formula on datasheet val + 6 * (val / 10)
+  writeByte(PCF8563T_HOUR_ALARM_REG, hour_alarm); //check formula on datasheet val + 6 * (val / 10)
 }
 
 /**


### PR DESCRIPTION
On the function `setHourAlarm` the register used was `PCF8563T_HOUR_REG` instead of `PCF8563T_HOUR_ALARM_REG`